### PR TITLE
스케줄러 devops 적용 테스트 (경로 오타 수정)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
 
                                 sh 'echo "[Schedule Sync] Git clone"'
                                 sh """
-                                ssh -i ${pemPath} ${localUser}@${localHost} "cd /mnt/c/User/dhcks/airflow/dags/SCHEDULE && git pull"
+                                ssh -i ${pemPath} ${localUser}@${localHost} "cd /mnt/c/Users/dhcks/airflow/dags/SCHEDULE && git pull"
                                 """
                                                 slackSend(channel: '#deployment-alert', color: '#00FF7F' , message: "[Schedule Sync] Git clone : Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
                             }


### PR DESCRIPTION
윈도우 로컬 경로 오타를 수정했습니다.

`/mnt/c/User/dhcks/airflow/dags/SCHEDULE`

-->

`/mnt/c/Users/dhcks/airflow/dags/SCHEDULE`